### PR TITLE
Fix crash when using --pacbio_model

### DIFF
--- a/src/plassembler/utils/input_commands.py
+++ b/src/plassembler/utils/input_commands.py
@@ -380,15 +380,15 @@ def validate_pacbio_model(pacbio_model):
     message = "You have specified using a pacbio model for Flye with --pacbio_model. Checking the input."
     logger.info(message)
 
-    if pacbio_model == "pacbio-raw":
+    if pacbio_model == "pacbio-raw" or pacbio_model == "--pacbio-raw":
         message = "You have selected pacbio-raw designed for PacBio regular CLR reads (<20% error)."
         logger.info(message)
         pacbio_model = "--pacbio-raw"
-    elif pacbio_model == "pacbio-corr":
+    elif pacbio_model == "pacbio-corr" or pacbio_model == "--pacbio-corr":
         message = "You have selected pacbio-corr designed for PacBio reads that were corrected with other methods (<3% error)."
         logger.info(message)
         pacbio_model = "--pacbio-corr"
-    elif pacbio_model == "pacbio-hifi":
+    elif pacbio_model == "pacbio-hifi" or pacbio_model == "--pacbio-hifi":
         message = (
             "You have selected pacbio-hifi designed for PacBio HiFi reads (<1% error)."
         )


### PR DESCRIPTION
Hi, George!

When I tried running `plassembler long` with `--pacbio_model pacbio-raw`, I got this error:
```
2025-06-13 12:46:35.920 | INFO     | plassembler.utils.input_commands:validate_pacbio_model:381 - You have specified using a pacbio model for Flye with --pacbio_model. Checking the input.
2025-06-13 12:46:35.920 | ERROR    | plassembler.utils.input_commands:validate_pacbio_model:399 - You pacbio model was not pacbio-raw, pacbio-corr or pacbio-hifi. Please check your input and run plassembler again.
```

I think the problem is that the `validate_pacbio_model` function is run multiple times. The [first time](https://github.com/gbouras13/plassembler/blob/813644991a809366d02f3cb4a33ca7555fcdacfb/src/plassembler/__init__.py#L1415) it is successful and it adds `--` onto the start of the `pacbio_model` variable. But when it's run a [second time](https://github.com/gbouras13/plassembler/blob/813644991a809366d02f3cb4a33ca7555fcdacfb/src/plassembler/__init__.py#L1573), it fails because it was looking for `pacbio-raw` and it got `--pacbio-raw` instead.

It might be possible to fix the crash by removing the second call, but that felt risky to me, and I'm not sure if the problem could occur with `plassembler run` as well. So this PR fixes the crash in what I think is the simplest way: it makes the `validate_pacbio_model` function accept models with or without the leading dashes, so it works the first and second time it's called.

Let me know if there's anything I can do to help test or investigate!

Ryan