### PR TITLE
Move the sys.exit sink after the log file sink

### DIFF
--- a/src/plassembler/__init__.py
+++ b/src/plassembler/__init__.py
@@ -71,8 +71,6 @@ def begin_plassembler(outdir, force):
     """
     # get start time
     start_time = time.time()
-    # error out on sys.exit
-    logger.add(lambda _: sys.exit(1), level="ERROR")
 
     # instantiate the outdir
     # remove outdir on force
@@ -97,6 +95,8 @@ def begin_plassembler(outdir, force):
     # adds log file
     logger.add(log_file)
     # ensure sys exit if error
+    logger.add(lambda _: sys.exit(1), level="ERROR")
+
     logger.info(f"You are using Plassembler version {get_version()}")
     logger.info("Repository homepage is https://github.com/gbouras13/plassembler")
     logger.info("Written by George Bouras: george.bouras@adelaide.edu.au")


### PR DESCRIPTION
Hi George,

I noticed that when Plassembler crashes, the error message doesn't end up in the log file.

For example, here's the end of my terminal output:
```
...
2025-06-20 08:05:59.967 | INFO     | plassembler:long:1510 - Counting Contigs.
2025-06-20 08:05:59.967 | INFO     | plassembler.utils.plass_class:get_contig_count:87 - Assembled 3 contigs.
2025-06-20 08:05:59.972 | ERROR    | plassembler:long:1535 - No chromosome was identified. Likely, there was insufficient long read depth to assemble a chromosome. 
Increasing sequencing depth is recommended. 
Also please check your -c or --chromosome parameter, it may be too high 
```

But here's the end of my `plassembler_*.log` file:
```
...
2025-06-20 08:05:59.967 | INFO     | plassembler:long:1510 - Counting Contigs.
2025-06-20 08:05:59.967 | INFO     | plassembler.utils.plass_class:get_contig_count:87 - Assembled 3 contigs.
```

In my tests, moving the `logger.add(lambda _: sys.exit(1), level="ERROR")` line after the `logger.add(log_file)` fixes this.

As always, let me know if there's anything I can do to help!

Ryan