### PR TITLE
Update input_commands.py

### DIFF
--- a/src/plassembler/utils/input_commands.py
+++ b/src/plassembler/utils/input_commands.py
@@ -227,6 +227,11 @@ def check_dependencies():
         process = sp.Popen(["unicycler", "--version"], stdout=sp.PIPE, stderr=sp.STDOUT)
         unicycler_out, _ = process.communicate()
         unicycler_out = unicycler_out.decode()
+        if "$TERM" in unicycler_out:
+            for line in unicycler_out.split('\n'):
+                if "unicycler" in line.lower():
+                    unicycler_out = line
+                    break
         unicycler_version = unicycler_out.split(" ")[1]
         # get rid of the "v"
         unicycler_version = unicycler_version[1:]


### PR DESCRIPTION
Fixes an issue when running plassembler on a job node where $TERM is not set
When running on a job node via e.g. qsub, you get the following warning message:
tput: No value for $TERM and no -T specified

As this warning message is sent to stdout, this makes it so plassembler thinks Unicycler is not in the path and exists.
This fix makes sure to take the correct line with the Unicycler version text, and avoids plassembler exiting.