### PR TITLE
docs: document the Pixi development workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,18 +57,19 @@ If you are proposing a feature:
 Get Started!
 ------------
 
-Ready to contribute? Here's how to set up `phrokka` for local development.
+Ready to contribute? Here's how to set up `plassembler` for local development.
 
-1. Fork the `phrokka` repo on GitHub.
+1. Fork the `plassembler` repo on GitHub.
 2. Clone your fork locally::
 
-    $ git clone git@github.com:your_name_here/phrokka.git
+    $ git clone git@github.com:your_name_here/plassembler.git
 
-3. Install your local copy into a virtualenv. Assuming you have virtualenvwrapper installed, this is how you set up your fork for local development::
+3. `plassembler` uses Pixi (https://pixi.sh) for development. Install the
+   environment - this pulls `plassembler` (editable) and all of its external
+   dependencies (Flye, Unicycler, samtools, mash, ...)::
 
-    $ mkvirtualenv phrokka
-    $ cd phrokka/
-    $ python setup.py develop
+    $ cd plassembler/
+    $ pixi install
 
 4. Create a branch for local development::
 
@@ -76,14 +77,13 @@ Ready to contribute? Here's how to set up `phrokka` for local development.
 
    Now you can make your changes locally.
 
-5. When you're done making changes, check that your changes pass flake8 and the
-   tests, including testing other Python versions with tox::
+5. When you're done making changes, check that the formatting/lint and the
+   tests pass::
 
-    $ flake8 phrokka tests
-    $ python setup.py test or pytest
-    $ tox
+    $ pixi run check-fmt
+    $ pixi run test
 
-   To get flake8 and tox, just pip install them into your virtualenv.
+   `pixi run fmt` will auto-format the code with ruff.
 
 6. Commit your changes and push your branch to GitHub::
 

--- a/README.md
+++ b/README.md
@@ -247,6 +247,19 @@ cd plassembler
 pip install -e .
 ```
 
+### Development (with Pixi)
+
+For development, `plassembler` uses [Pixi](https://pixi.sh). `pixi install` creates an environment containing `plassembler` (editable) along with **all** of its external dependencies (Flye, Unicycler, SPAdes, mash, samtools, minimap2, fastp, chopper, Raven, canu, dnaapler):
+
+```
+git clone https://github.com/gbouras13/plassembler.git
+cd plassembler
+pixi install
+pixi run plassembler --help
+```
+
+`pixi run <cmd>` runs a command inside the project environment (e.g. `pixi run test` to run the test suite), and `pixi shell` activates it.
+
 ## Unicycler v0.5.0 Installation Issues
 
 `plassembler` works best with Unicycler v0.5.0. With Unicycler v0.4.8, `plassembler` should still run without any issue and provide a satisfactory assembly, but you will be warned of this when you run `plassembler`. `plassembler` will not work with any older version of Unicycler.

--- a/docs/install.md
+++ b/docs/install.md
@@ -47,6 +47,19 @@ cd plassembler
 pip install -e .
 ```
 
+### Development (with Pixi)
+
+For development, plassembler uses [Pixi](https://pixi.sh). `pixi install` creates an environment containing plassembler (editable) along with all of its external dependencies (Flye, Unicycler, SPAdes, mash, samtools, minimap2, fastp, chopper, Raven, canu, dnaapler):
+
+```
+git clone https://github.com/gbouras13/plassembler.git
+cd plassembler
+pixi install
+pixi run plassembler --help
+```
+
+`pixi run <cmd>` runs a command inside the project environment (e.g. `pixi run test` runs the test suite), and `pixi shell` activates it.
+
 ## Unicycler v0.5.0 Installation Issues
 
 `plassembler` works best with Unicycler v0.5.0. With Unicycler v0.4.8, `plassembler` should still run without any issue and provide a satisfactory assembly, but you will be warned of this when you run `plassembler`. `plassembler` will not work with any older version of Unicycler.


### PR DESCRIPTION
Add a "Development (with Pixi)" section to the README and install docs, and refresh the stale CONTRIBUTING dev-setup (it still referenced pharokka and `python setup.py develop`) to use `pixi install` / `pixi run`.